### PR TITLE
Fix algorithm run loop

### DIFF
--- a/implementations/original.py
+++ b/implementations/original.py
@@ -1,12 +1,13 @@
 import math
 
 from implementations.template import CascadeTemplate
+from study.statistics import Statistics
 
 
 class OriginalCascade(CascadeTemplate):
 
-    def __init__(self, correct_party, key):
-        CascadeTemplate.__init__(self, correct_party, key)
+    def __init__(self, correct_party, key, stats):
+        CascadeTemplate.__init__(self, correct_party, key, stats)
         self.error_rate = self.estimate_error()
         self.num_iterations = 4
 
@@ -19,5 +20,3 @@ class OriginalCascade(CascadeTemplate):
             return blocks
 
         return self.shuffle_blocks(block_size * pow(2, iter_num))
-
-

--- a/implementations/template.py
+++ b/implementations/template.py
@@ -62,10 +62,12 @@ class CascadeTemplate(object):
             parities = self.calculate_parities(iterations[iter_num])
 
             correct_parities = self.correct_party.calculate_parities(iterations[iter_num])
-            self.stats.register_channel_use(self.id, {'len': len(correct_parities)})
+            # self.stats.register_channel_use(self.id,)
+            self.stats.start_iteration(self.id, {'len': len(correct_parities)})
 
             for i in range(0, len(correct_parities)):
                 if parities[i] != correct_parities[i]:
+                    self.stats.start_block(self.id)
                     corrected_index = iterations[iter_num][i][0]
                     for j in range(0, iter_num + 1):
                         correcting_block = self._get_block_containing_index(iterations[iter_num - j],

--- a/implementations/template.py
+++ b/implementations/template.py
@@ -1,13 +1,16 @@
 import math
 import random
+import time
 
 
 class CascadeTemplate(object):
 
-    def __init__(self, correct_party, key):
+    def __init__(self, correct_party, key, stats):
         self.correct_party = correct_party
         self.key = key
         self.num_iterations = 0
+        self.stats = stats
+        self.id = str(time.time())
 
     def calculate_parity(self, indexes):
         parity = 0
@@ -52,10 +55,14 @@ class CascadeTemplate(object):
     def run_algorithm(self):
         iterations = []
 
+        self.stats.initialize_run(self.id, self.correct_party.key.bin, self.key.bin, self.estimate_error())
+
         for iter_num in range(0, self.num_iterations):
             iterations.append(self.get_iteration_blocks(iter_num))
             parities = self.calculate_parities(iterations[iter_num])
+
             correct_parities = self.correct_party.calculate_parities(iterations[iter_num])
+            self.stats.register_channel_use(self.id, {'len': len(correct_parities)})
 
             for i in range(0, len(correct_parities)):
                 if parities[i] != correct_parities[i]:
@@ -69,6 +76,8 @@ class CascadeTemplate(object):
                         if corrected_index is not None:
                             self.key.invert(corrected_index)
 
+        self.stats.end_run(self.id, self.key.bin)
+
     def _binary(self, block):
         """
         Finds the index of an odd error in the given block
@@ -77,6 +86,7 @@ class CascadeTemplate(object):
         """
         first_half_size = math.ceil(len(block) / 2)
         correct_first_half_par = self.correct_party.calculate_parity(block[:first_half_size])
+        self.stats.register_channel_use(self.id, {'len': 1})
 
         first_half_par = self.calculate_parity(block[:first_half_size])
 

--- a/study/run.py
+++ b/study/run.py
@@ -1,0 +1,16 @@
+from bitstring import BitArray
+
+from implementations.original import OriginalCascade
+from implementations.template import CascadeTemplate
+from study.statistics import Statistics
+
+if __name__ == '__main__':
+
+    c_key = '1111111111111111111111111111111111111111'
+    key =   '1011111111100011111111011111111111111100'
+
+    stats = Statistics('testfile.csv')
+
+    run = OriginalCascade(CascadeTemplate(BitArray(bin=c_key), BitArray(bin=c_key), None), BitArray(bin=key), stats)
+    run.run_algorithm()
+    print(run.correct_party.key, run.key)

--- a/study/statistics.py
+++ b/study/statistics.py
@@ -16,8 +16,14 @@ class Statistics(object):
     def initialize_run(self, id, c_key, key, error):
         self.status[id] = Status(c_key, key, error)
 
+    def start_iteration(self, id, channel_use):
+        self.status[id].start_iteration(channel_use)
+
+    def start_block(self, id):
+        self.status[id].start_block()
+
     def register_channel_use(self, id, channel_use):
-        self.status[id].channel_uses.append(channel_use['len'])
+        self.status[id].add_channel_use(channel_use)
 
     def end_run(self, id, key):
         self.status[id].final_key = key

--- a/study/statistics.py
+++ b/study/statistics.py
@@ -1,0 +1,28 @@
+import os
+
+from study.status import Status
+
+
+class Statistics(object):
+
+    def __init__(self, filename):
+        os.makedirs(os.path.dirname(os.path.abspath(filename)), exist_ok=True)
+        if not os.path.isfile(filename):
+            with open(filename, 'w') as f:
+                f.write('correct key, initial key, final key, error rate, correct, ber, efficiency, channel_uses\n')
+        self.filename = filename
+        self.status = {}
+
+    def initialize_run(self, id, c_key, key, error):
+        self.status[id] = Status(c_key, key, error)
+
+    def register_channel_use(self, id, channel_use):
+        self.status[id].channel_uses.append(channel_use['len'])
+
+    def end_run(self, id, key):
+        self.status[id].final_key = key
+
+        self.status[id].calculate_parameters()
+
+        self.status[id].flush_to_file(self.filename)
+        del self.status[id]

--- a/study/status.py
+++ b/study/status.py
@@ -14,18 +14,48 @@ class Status(object):
         self.bit_error_ratio = 0
         self.efficiency = 1.0
 
+    def start_iteration(self, channel_use):
+        self.channel_uses.append([channel_use['len']])
+
+    def start_block(self):
+        self.channel_uses[-1].append([])
+
+    def add_channel_use(self, channel_use):
+        self.channel_uses[-1][-1].append(channel_use['len'])
+        # print(self.channel_uses)
+
     def _calculate_ber(self):
         num_errors = 0
         for i in range(0, len(self.final_key)):
             num_errors += int(self.final_key[i]) ^ int(self.correct_key[i])
         return num_errors / len(self.final_key)
 
+    def _deep_sum(self, lst):
+        return sum(self._deep_sum(el) if isinstance(el, list) else el for el in lst)
+
+    def exchanged_msg_len(self):
+        return self._deep_sum(self.channel_uses)
+
+    def num_channel_uses(self):
+        num = 0
+        for iteration in self.channel_uses:
+            num += 1
+            max_len = 0
+            for i in range(1, len(iteration)):  # for each iteration get the minimum needed number of uses
+                max_len = max(max_len, len(iteration[i]))
+            num += max_len
+        return num
+
     def _calculate_efficiency(self):
         """
-        TODO: other formula was: return (1 - sum(self.channel_uses)/len(self.initial_key))/ (
-        -self.error_rate*log2(self.error_rate)-(1-self.error_rate)*log2(1-self.error_rate))
+        TODO: other formula was: return
+        sum(self.channel_uses) / (len(self.initial_key) * -len(self.initial_key) * log2(1 - self.error_rate))
         """
-        return sum(self.channel_uses) / (len(self.initial_key) * len(self.initial_key) * (1 - self.error_rate))
+        # print(1 - sum(self.channel_uses)/len(self.initial_key))
+        # print(self.error_rate)
+        # print( -self.error_rate*log2(self.error_rate)-(1-self.error_rate)*log2(1-self.error_rate))
+        return (1 - self.exchanged_msg_len() / len(self.initial_key)) / (
+            -self.error_rate*log2(self.error_rate)-(1-self.error_rate)*log2(1-self.error_rate))
 
     def calculate_parameters(self):
         if self.final_key != self.correct_key:
@@ -43,6 +73,6 @@ class Status(object):
                                                    self.correct,
                                                    self.bit_error_ratio,
                                                    self.efficiency,
-                                                   self.channel_uses))
+                                                   self.num_channel_uses()))
 
 

--- a/study/status.py
+++ b/study/status.py
@@ -1,0 +1,48 @@
+from math import log2
+
+
+class Status(object):
+
+    def __init__(self, correct_key, initial_key, error_rate):
+        self.correct_key = correct_key
+        self.initial_key = initial_key
+        self.error_rate = error_rate
+
+        self.final_key = None
+        self.channel_uses = []
+        self.correct = True
+        self.bit_error_ratio = 0
+        self.efficiency = 1.0
+
+    def _calculate_ber(self):
+        num_errors = 0
+        for i in range(0, len(self.final_key)):
+            num_errors += int(self.final_key[i]) ^ int(self.correct_key[i])
+        return num_errors / len(self.final_key)
+
+    def _calculate_efficiency(self):
+        """
+        TODO: other formula was: return (1 - sum(self.channel_uses)/len(self.initial_key))/ (
+        -self.error_rate*log2(self.error_rate)-(1-self.error_rate)*log2(1-self.error_rate))
+        """
+        return sum(self.channel_uses) / (len(self.initial_key) * len(self.initial_key) * (1 - self.error_rate))
+
+    def calculate_parameters(self):
+        if self.final_key != self.correct_key:
+            self.correct = False
+            self.bit_error_ratio = self._calculate_ber()
+
+        self.efficiency = self._calculate_efficiency()
+
+    def flush_to_file(self, filename):
+        with open(filename, 'a') as f:
+            f.write('%s,%s,%s,%s,%s,%s,%s,%s\n' % (self.correct_key,
+                                                   self.initial_key,
+                                                   self.final_key,
+                                                   self.error_rate,
+                                                   self.correct,
+                                                   self.bit_error_ratio,
+                                                   self.efficiency,
+                                                   self.channel_uses))
+
+


### PR DESCRIPTION
Calling the binary protocol in the "cascade effect" without updating and checking the parity of the block in the previous iterations was causing the algorithm to have really big error rates. 

Solution was to save the parities of past iterations and update all of them on each bit fix, then check them before calling the binary protocol (this was only checked for the first correction of the cascade effect)