### PR TITLE
[DONE] Improve channel uses parallelization approach

### DIFF
--- a/cascade-study/implementations/biconf.py
+++ b/cascade-study/implementations/biconf.py
@@ -1,9 +1,6 @@
 import math
 
-from datasets.generator import _generate_keypair
 from implementations.template import CascadeTemplate
-from study.status import Status
-from utils.key import Key
 
 
 class CascadeBiconf(CascadeTemplate):

--- a/cascade-study/implementations/template.py
+++ b/cascade-study/implementations/template.py
@@ -52,6 +52,7 @@ class CascadeTemplate(object):
 
             for i in range(0, len(correct_parities[iter_num])):
                 corrected_index = iterations[iter_num][i][0]
+                self.status.start_block()
                 for j in range(0, iter_num + 1):
                     correcting_block = self._get_block_containing_index(iterations[iter_num - j],
                                                                         corrected_index)
@@ -59,7 +60,6 @@ class CascadeTemplate(object):
                         continue
                     if parities[iter_num - j].bin[correcting_block] != \
                             correct_parities[iter_num - j].bin[correcting_block]:
-                        self.status.start_block()
                         corrected_index = self._binary(iterations[iter_num - j][correcting_block])
                         if corrected_index is not None:
                             self.key.invert(corrected_index)

--- a/cascade-study/study/status.py
+++ b/cascade-study/study/status.py
@@ -72,6 +72,7 @@ class Status(object):
     def num_channel_uses(self):
         num = 0
         for iteration in self.channel_uses:
+            iteration = list(filter(None, iteration))
             num += 1
             max_len = 0
             for i in range(1, len(iteration)):  # for each iteration get the minimum needed number of uses

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -24,12 +24,12 @@ class TestCascadeTemplate(unittest.TestCase):
 
     def test_num_channel_uses(self):
         status = Status('/tmp/test', 'test', 0, 0)
-        status.channel_uses = [[8, [1, 1, 1], [1], [1, 1, 1, 1]], [3, [1], [1], [1]], [5, [2, 3], [1, 1, 1]]]
+        status.channel_uses = [[8, [], [1, 1, 1], [1], [1, 1, 1, 1]], [3, [1], [1], [1]], [5, [2, 3], [1, 1, 1]]]
 
         self.assertEqual(status.num_channel_uses(), 11)
 
     def test_exchanged_msg_len(self):
         status = Status('/tmp/test', 'test', 0, 0)
-        status.channel_uses = [[8, [1, 1, 1], [1], [1, 1, 1, 1]], [3, [1], [1], [1]], [5, [2, 3], [1, 1, 1]]]
+        status.channel_uses = [[8, [1, 1, 1], [1], [1, 1, 1, 1]], [3, [1], [1], [], [1]], [5, [2, 3], [1, 1, 1]]]
 
         self.assertEqual(status.exchanged_msg_len(), 35)


### PR DESCRIPTION
Approach tweak:

- In every iteration, each block has the initial message and a list. If there is no needed communication for that block the list stays empty (and is filtered out on the calculation of the channel uses number). If there is communication, its length will be appended to the the list. 
- The processing of all blocks in an iteration should be parallel, so only the length of largest list counts, the others are assumed to be sent together with the messages of the largest list.

Closes #23 